### PR TITLE
Fix Docker build for Railway

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .stxxl
-disk=/tmp/.stxxl
 __pycache__/
 api/__pycache__/
 data/

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM osrm/osrm-backend as builder
 WORKDIR /data
 COPY data/odessa_oblast.osm.pbf /data/
-COPY .stxxl /root/.stxxl
+RUN echo 'disk=/tmp/stxxl,10G,syscall' > /root/.stxxl
 RUN osrm-extract -p /opt/car.lua /data/odessa_oblast.osm.pbf && \
     osrm-partition /data/odessa_oblast.osrm && \
     osrm-customize /data/odessa_oblast.osrm

--- a/README.md
+++ b/README.md
@@ -14,18 +14,17 @@ osrm-odessa/
 ├── data/
 │   └── odessa_oblast.osm.pbf
 ├── Dockerfile
-├── .stxxl
 ├── .gitignore
 └── README.md
 ```
 
-В каталоге `data` должен находиться файл `odessa_oblast.osm.pbf`, скачанный с [Geofabrik](https://download.geofabrik.de/). Файл `.stxxl` требуется для дискового кеширования и содержит:
+В каталоге `data` должен находиться файл `odessa_oblast.osm.pbf`, скачанный с [Geofabrik](https://download.geofabrik.de/). Во время сборки контейнера автоматически создаётся файл `.stxxl` со строкой:
 
 ```
 disk=/tmp/stxxl,10G,syscall
 ```
 
-Оба файла исключены из Git при помощи `.gitignore`.
+Файлы данных и `.stxxl` не добавляются в Git благодаря `.gitignore`.
 
 ## Использование
 ### Сборка и запуск локально

--- a/tests/test_dockerfile.py
+++ b/tests/test_dockerfile.py
@@ -1,0 +1,7 @@
+"""Тест Dockerfile на создание файла .stxxl."""
+from pathlib import Path
+
+def test_stxxl_created():
+    dockerfile = Path('Dockerfile').read_text()
+    assert "disk=/tmp/stxxl,10G,syscall" in dockerfile
+    assert "COPY .stxxl" not in dockerfile


### PR DESCRIPTION
## Summary
- create `.stxxl` during Docker build instead of copying
- document automated `.stxxl` creation
- clean `.gitignore`
- add test for Dockerfile

## Testing
- `pytest -q`
- `docker build` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_b_6873a8bcc10c8320ba613857d26a22d9